### PR TITLE
Improve pyOSC3 compatibility for TCP communication using Python 3.7+

### DIFF
--- a/pyOSC3/OSC3.py
+++ b/pyOSC3/OSC3.py
@@ -2855,8 +2855,6 @@ class OSCStreamingClient(OSCAddressSpace):
         length = len(binary)
         # prepend length of packet before the actual message (big endian)
         len_big_endian = struct.pack('>L', length)
-        struct.pack_into(">L", len_big_endian, 0, length)
-        len_big_endian = len_big_endian.tostring()
         if self._transmitWithTimeout(len_big_endian) and self._transmitWithTimeout(binary):
             return True
         else:

--- a/pyOSC3/OSC3.py
+++ b/pyOSC3/OSC3.py
@@ -2734,7 +2734,7 @@ class OSCStreamingClient(OSCAddressSpace):
         self._running = False
         
     def _receiveWithTimeout(self, count):
-        chunk = str()
+        chunk = bytes()
         while len(chunk) < count:
             try:
                 tmp = self.socket.recv(count - len(chunk))

--- a/pyOSC3/OSC3.py
+++ b/pyOSC3/OSC3.py
@@ -2854,7 +2854,7 @@ class OSCStreamingClient(OSCAddressSpace):
         binary = msg.getBinary()
         length = len(binary)
         # prepend length of packet before the actual message (big endian)
-        len_big_endian = array.array('c', '\0' * 4)
+        len_big_endian = struct.pack('>L', length)
         struct.pack_into(">L", len_big_endian, 0, length)
         len_big_endian = len_big_endian.tostring()
         if self._transmitWithTimeout(len_big_endian) and self._transmitWithTimeout(binary):


### PR DESCRIPTION
This PR improves the compatibility with Python 3.7+ for pyOSC3 communication using TCP.

Fixes #4
Fixes #5 